### PR TITLE
BUG: remove the secure connection to NITRC

### DIFF
--- a/SuperBuild/External_DTIPrep.cmake
+++ b/SuperBuild/External_DTIPrep.cmake
@@ -56,7 +56,7 @@ set(${proj}_CMAKE_OPTIONS
   )
 
 ### --- End Project specific additions
-set(${proj}_REPOSITORY https://www.nitrc.org/svn/dtiprep/trunk)
+set(${proj}_REPOSITORY http://www.nitrc.org/svn/dtiprep/trunk)
 ExternalProject_Add(${proj}
   SVN_REPOSITORY ${${proj}_REPOSITORY}
   SVN_REVISION -r "293"

--- a/SuperBuild/External_DTIProcess.cmake
+++ b/SuperBuild/External_DTIProcess.cmake
@@ -20,7 +20,7 @@ set(${proj}_CMAKE_OPTIONS
   )
 
 ### --- End Project specific additions
-set(${proj}_REPOSITORY "https://www.nitrc.org/svn/dtiprocess/trunk")
+set(${proj}_REPOSITORY "http://www.nitrc.org/svn/dtiprocess/trunk")
 set(${proj}_SVN_REVISION -r "218")
 ExternalProject_Add(${proj}
   SVN_REPOSITORY ${${proj}_REPOSITORY}

--- a/SuperBuild/External_DTIReg.cmake
+++ b/SuperBuild/External_DTIReg.cmake
@@ -47,7 +47,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${proj}" AND "${USE_SYSTEM_${proj}}" ) )
     )
 
   ### --- End Project specific additions
-  set(${proj}_REPOSITORY https://www.nitrc.org/svn/dtireg/trunk)
+  set(${proj}_REPOSITORY http://www.nitrc.org/svn/dtireg/trunk)
   set(${proj}_REVISION -r "69") ## Fix SlicerExecutionModel find_package
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_DTI_Tract_Stat.cmake
+++ b/SuperBuild/External_DTI_Tract_Stat.cmake
@@ -62,7 +62,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
 
   ### --- End Project specific additions
-  set(${proj}_REPOSITORY "https://www.nitrc.org/svn/dti_tract_stat/trunk")
+  set(${proj}_REPOSITORY "http://www.nitrc.org/svn/dti_tract_stat/trunk")
   ExternalProject_Add(${proj}
     SVN_REPOSITORY ${${proj}_REPOSITORY}
     SVN_REVISION -r "137"

--- a/SuperBuild/External_niral_utilities.cmake
+++ b/SuperBuild/External_niral_utilities.cmake
@@ -74,7 +74,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
 
   ### --- End Project specific additions
-  set(${proj}_REPOSITORY "https://www.nitrc.org/svn/niral_utilities/trunk")
+  set(${proj}_REPOSITORY "http://www.nitrc.org/svn/niral_utilities/trunk")
   set(${proj}_SVN_REVISION -r "56")
   ExternalProject_Add(${proj}
     SVN_REPOSITORY ${${proj}_REPOSITORY}


### PR DESCRIPTION
The external resources cannot be downloaded from NITRC website if the user
does not have a NITRC accounts. Therefore, all https connections are
replaced by http.
